### PR TITLE
Doc(eos_cli_config_gen): fix ntp release notes

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -361,7 +361,7 @@ ntp:
     name: < source_interface >
     vrf: < vrf_name >
   servers:
-  - name: < IP | hostname >:
+  - name: < IP | hostname >
     burst: < true | false >
     iburst:  < true | false >
     key: < 1 - 65535 >


### PR DESCRIPTION

## Change Summary

Fixed typo in release note on new data structure for NTP, removed extra ":" for server name Change Summary

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

eos_cli_config_gen

## Proposed changes
Removed extra : from ntp server name in new devel branch ntp syntax

## How to test


## Checklist

### User Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [x ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
